### PR TITLE
(draft) fix: apply temporal rtl fix

### DIFF
--- a/i18n/en/oboete.ftl
+++ b/i18n/en/oboete.ftl
@@ -49,6 +49,7 @@ folder-name = Folder Name
 
 <#-- Folder Details Context Page -->
 folder-details = Folder Details
+folder-rtl-fix = RTL Fix
 
 <#-- Flashcards Page -->
 ok-status = Ok

--- a/src/app.rs
+++ b/src/app.rs
@@ -597,8 +597,8 @@ impl cosmic::Application for Oboete {
                             );
                         }
 
-                        //Opens a folder => Loads the flashcards of a given folder => Updates the current_folder_id
-                        homepage::HomePageTask::OpenFolder(folder_id) => {
+                        //Opens a folder => Loads the flashcards of a given folder => Updates the current_folder_id and rtlx fix
+                        homepage::HomePageTask::OpenFolder(folder_id, rtl_fix) => {
                             tasks.push(Task::perform(
                                 Flashcard::get_all(self.database.clone().unwrap(), folder_id),
                                 |result| match result {
@@ -610,6 +610,7 @@ impl cosmic::Application for Oboete {
                             ));
                             self.current_page = Page::FolderContent;
                             self.folder_content.set_current_folder_id(Some(folder_id));
+                            self.folder_content.set_current_rtlfix(rtl_fix);
                         }
                     }
                 }
@@ -814,12 +815,12 @@ impl cosmic::Application for Oboete {
                         }
 
                         // Retrieves the flashcard of a folder and gives it to the studypage
-                        folder_content::FolderContentTask::StudyFolder(folder_id) => {
+                        folder_content::FolderContentTask::StudyFolder(folder_id, rtl_fix) => {
                             tasks.push(Task::perform(
                                 Flashcard::get_all(self.database.clone().unwrap(), folder_id),
-                                |result| match result {
+                                move |result| match result {
                                     Ok(flashcards) => cosmic::action::app(Message::StudyPage(
-                                        study_page::Message::SetFlashcards(flashcards),
+                                        study_page::Message::SetFlashcards(flashcards, rtl_fix),
                                     )),
                                     Err(_) => cosmic::action::none(),
                                 },
@@ -1093,6 +1094,7 @@ impl cosmic::Application for Oboete {
             self.current_page = Page::HomePage;
             self.homepage.set_current_studyset_id(Some(*set_id));
             self.folder_content.set_current_folder_id(None);
+            self.folder_content.set_current_rtlfix(false);
             self.folder_content.clean_flashcards_vec();
 
             // If a studyset is clicked ask for the folders of the studyset to be fetched

--- a/src/oboete/models/folder.rs
+++ b/src/oboete/models/folder.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 pub struct Folder {
     pub id: Option<i32>,
     pub name: String,
+    #[serde(default)]
+    pub rtl_fix: bool,
     pub flashcards: Vec<super::flashcard::Flashcard>,
 }
 
@@ -17,25 +19,29 @@ impl Folder {
         Folder {
             id: None,
             name,
+            rtl_fix: false,
             flashcards: Vec::new(),
         }
     }
 
     pub async fn get_all(pool: Arc<Pool<Sqlite>>, set_id: i32) -> Result<Vec<Folder>, sqlx::Error> {
-        let mut rows =
-            sqlx::query("SELECT id, name FROM folders WHERE studyset_id = $1 ORDER BY id ASC")
-                .bind(set_id)
-                .fetch(pool.as_ref());
+        let mut rows = sqlx::query(
+            "SELECT id, name, rtl_fix FROM folders WHERE studyset_id = $1 ORDER BY id ASC",
+        )
+        .bind(set_id)
+        .fetch(pool.as_ref());
 
         let mut result = Vec::<Folder>::new();
 
         while let Some(row) = rows.try_next().await? {
             let id: i32 = row.try_get("id")?;
             let name: String = row.try_get("name")?;
+            let rtl_fix: bool = row.try_get("rtl_fix")?;
 
             let folder = Folder {
                 id: Some(id),
                 name,
+                rtl_fix,
                 flashcards: Vec::new(),
             };
 
@@ -46,8 +52,9 @@ impl Folder {
     }
 
     pub async fn edit(pool: Arc<Pool<Sqlite>>, folder: Folder) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE folders SET name = $1 WHERE id = $2")
+        sqlx::query("UPDATE folders SET name = $1, rtl_fix = $2 WHERE id = $3")
             .bind(&folder.name)
+            .bind(folder.rtl_fix)
             .bind(folder.id)
             .execute(pool.as_ref())
             .await?;

--- a/src/oboete/pages/folder_content.rs
+++ b/src/oboete/pages/folder_content.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 pub struct FolderContent {
+    current_folder_rtl_fix: bool,
     current_folder_id: Option<i32>,
     // Flashcards inside the folder
     flashcards: Vec<Flashcard>,
@@ -102,7 +103,7 @@ pub enum Message {
     OpenFolderExportResult(Vec<String>, ExportOptions),
 
     // Change to Study Page
-    StudyFolder(i32),
+    StudyFolder(i32, bool),
 }
 
 pub enum FolderContentTask {
@@ -121,17 +122,23 @@ pub enum FolderContentTask {
     RestartFolderFlashcardsStatus(i32), // We pass the folder_id
     OpenFolderExport(ExportOptions),
 
-    StudyFolder(i32),
+    StudyFolder(i32, bool),
 }
 
 impl FolderContent {
     pub fn init() -> Self {
         Self {
             current_folder_id: None,
+            current_folder_rtl_fix: false,
             flashcards: Vec::new(),
             add_edit_flashcard: AddEditFlashcardState::new(),
             folder_options_state: FolderOptionsContextPageState::new(),
         }
+    }
+
+    /// Sets the value of the currently selected folder
+    pub fn set_current_rtlfix(&mut self, value: bool) {
+        self.current_folder_rtl_fix = value;
     }
 
     /// Sets the value of the currently selected folder
@@ -342,8 +349,8 @@ impl FolderContent {
             }
 
             // Asks for the study mode for a given folder (page change)
-            Message::StudyFolder(folder_id) => {
-                tasks.push(FolderContentTask::StudyFolder(folder_id));
+            Message::StudyFolder(folder_id, rtl_fix) => {
+                tasks.push(FolderContentTask::StudyFolder(folder_id, rtl_fix));
             }
         }
 
@@ -441,7 +448,10 @@ impl FolderContent {
         let study_button = if !self.flashcards.is_empty() {
             widget::button::text("Study")
                 .class(theme::Button::Suggested)
-                .on_press(Message::StudyFolder(self.current_folder_id.unwrap()))
+                .on_press(Message::StudyFolder(
+                    self.current_folder_id.unwrap(),
+                    self.current_folder_rtl_fix,
+                ))
         } else {
             widget::button::text("Study").class(theme::Button::Suggested)
         };

--- a/src/oboete/pages/homepage.rs
+++ b/src/oboete/pages/homepage.rs
@@ -21,6 +21,7 @@ pub struct HomePage {
 pub struct EditFolderState {
     id: Option<i32>,
     name: String,
+    rtl_fix: bool,
 }
 
 impl EditFolderState {
@@ -28,6 +29,7 @@ impl EditFolderState {
         EditFolderState {
             id: None,
             name: String::new(),
+            rtl_fix: false,
         }
     }
 }
@@ -45,10 +47,11 @@ pub enum Message {
 
     OpenEditContextPage(Folder),
     EditFolderNameInput(String),
+    ToggleRLTCheckboxValue,
 
     OpenCreateFolderDialog,
 
-    OpenFolder(i32),
+    OpenFolder(i32, bool),
 }
 
 pub enum HomePageTask {
@@ -61,7 +64,7 @@ pub enum HomePageTask {
 
     OpenCreateFolderDialog,
 
-    OpenFolder(i32),
+    OpenFolder(i32, bool),
 }
 
 impl HomePage {
@@ -99,6 +102,7 @@ impl HomePage {
                 tasks.push(HomePageTask::EditFolder(Folder {
                     id: self.edit_folder.id,
                     name: self.edit_folder.name.to_string(),
+                    rtl_fix: self.edit_folder.rtl_fix,
                     flashcards: Vec::new(),
                 }));
             }
@@ -141,6 +145,7 @@ impl HomePage {
                 self.edit_folder = EditFolderState {
                     id: folder.id,
                     name: folder.name,
+                    rtl_fix: folder.rtl_fix,
                 };
                 tasks.push(HomePageTask::OpenEditContextPage);
             }
@@ -148,14 +153,17 @@ impl HomePage {
             // Updates the value of the folder name in the edit contextpage
             Message::EditFolderNameInput(value) => self.edit_folder.name = value,
 
+            // Toggles the value of the RTL fix bool
+            Message::ToggleRLTCheckboxValue => self.edit_folder.rtl_fix = !self.edit_folder.rtl_fix,
+
             // Asks for the create folder dialog to be open on main
             Message::OpenCreateFolderDialog => {
                 tasks.push(HomePageTask::OpenCreateFolderDialog);
             }
 
             // Asks for the given folder to be opened (page change)
-            Message::OpenFolder(folder_id) => {
-                tasks.push(HomePageTask::OpenFolder(folder_id));
+            Message::OpenFolder(folder_id, rtl_fix) => {
+                tasks.push(HomePageTask::OpenFolder(folder_id, rtl_fix));
             }
         }
 
@@ -187,7 +195,7 @@ impl HomePage {
                         widget::button::icon(icons::get_handle("folder-open-symbolic", 18))
                             .class(theme::Button::Suggested)
                             .width(Length::Shrink)
-                            .on_press(Message::OpenFolder(folder.id.unwrap()));
+                            .on_press(Message::OpenFolder(folder.id.unwrap(), folder.rtl_fix));
 
                     let folder_name = widget::text(folder.name.clone())
                         .align_y(Vertical::Center)
@@ -299,6 +307,15 @@ impl HomePage {
                         widget::text::body(fl!("folder-name")).into(),
                         widget::text_input(fl!("folder-name"), &self.edit_folder.name)
                             .on_input(Message::EditFolderNameInput)
+                            .into(),
+                    ])
+                    .spacing(spacing.space_xxs),
+                )
+                .add(
+                    widget::column::with_children(vec![
+                        //widget::text::body(fl!("folder-rtl-fix")).into(),
+                        widget::checkbox(fl!("folder-rtl-fix"), self.edit_folder.rtl_fix)
+                            .on_toggle(|_| Message::ToggleRLTCheckboxValue)
                             .into(),
                     ])
                     .spacing(spacing.space_xxs),


### PR DESCRIPTION
This PR attempts to apply a temporary fix to allow the use of RTL languages in the application by enabling the user to set a per-folder flag that changes how the application handles the viewing of flashcards while studying. This is a draft, as I do not like this implementation for various reasons (even though it works).

1 - Too many code changes: Due to how the application code is organized, adding this single field results in too many confusing changes. The code is already complex enough, and perhaps we can postpone this change to a future GUI rewrite.

2 - Even though you can now see RTL words while studying, it's too distracting, as the view keeps bouncing left and right (because no centering is applied—non-RTL text ends up in the top-left, while RTL text ends up in the top-right). See video:

[Screencast_20250620_104715.webm](https://github.com/user-attachments/assets/55f32f57-a811-4a02-949a-a95289fcc99e)
